### PR TITLE
Add a travis-ci build status badge to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 <img src=".doc/pictures/terrarium.jpg" width=250px height=250px>
 
 [![Code of Conduct][coc-badge]][coc]
+[![Build Status](https://img.shields.io/travis-ci/MalloZup/ceph-open-terrarium.svg?branch=master&style=for-the-badge)](https://travis-ci.org/MalloZup/ceph-open-terrarium)
 
 Ceph-open-terrarium lets deploy a ceph cluster on libvirt-kvm via terraform with saltstack or ansible or any other config mgmt tool.
 


### PR DESCRIPTION
This PR adds a travis-ci build status badge to the README.md file. Fixes #27 - see below for style:
![ceph-open-terrarium-build-status-icon](https://user-images.githubusercontent.com/3108461/46842095-abc05880-cd99-11e8-8baa-ad816445e015.png)
