### PR TITLE
Fixes pylint warnings for create_roster.py - Fixes #18

### DIFF
--- a/salt/create_roster.py
+++ b/salt/create_roster.py
@@ -1,51 +1,87 @@
-#! /usr/bin/python
+#!/usr/bin/python
+"""
+This simple script takes the hosts.txt file and converts the ips dynamically to salt-ssh roster.
+This is a workaround until https://github.com/MalloZup/ceph-open-terrarium/issues/7 is closed.
+There is not much need to make it better since it will removed.
+"""
+import os
+import sys
 
-# this simple script take the hosts.txt files and convert the ip dinamically to salt-ssh roster.
-# this is a workaround until https://github.com/MalloZup/ceph-open-terrarium/issues/7
-# there is no much need to make it better since it will removed.
-import os, sys
-roster_file = "etc/salt/roster"
-terraformHostsFile = "../hosts.txt"
-
-def readIpfromTerraform(hostFile):
-    with open(hostFile) as f:
-        ips = f.read().splitlines()
-    return ips
-
-def writeSaltMasterEntry(rosterFile, iphost):
-    rosterFile.write(" salt-master:" + '\n')
-    rosterFile.write("   user: root" + '\n')
-    rosterFile.write("   host: " + str(iphost) + '\n')
+DEFAULT_ROSTER_FILE = "etc/salt/roster"
+TERRAFORM_HOSTS_FILE = "../hosts.txt"
 
 
-def writeSaltMinionEntry(rosterFile, iphost, minionNumber):
-    rosterFile.write(" salt-minion"  + str(minionNumber)  + ': \n')
-    rosterFile.write("   user: root" + '\n')
-    rosterFile.write("   host: " + str(iphost) + '\n')
+def read_ip_from_terraform(host_file):
+    """
+    Opens the specified file by name and returns a list. Each element of the
+    list corresponds to one line in the file. Newline characters are removed
+    from each line of the file.
 
-# host.txt was deleted just exit
-if not os.path.exists(terraformHostsFile):
-  print("host.txt doesn't exist anymore.")
-  sys.exit(1)
+    :param host_file: the name of te file to open
+    :return: a list of strings - each element is a line from the file
+    """
+    with open(host_file) as open_file:
+        return open_file.read().splitlines()
 
-# read terraform ips
-if os.path.exists(roster_file):
-    os.remove(roster_file)
 
-ips = readIpfromTerraform(terraformHostsFile)
-if not ips:
-  print("host.txt empty")
-  sys.exit(1)
+def write_salt_master_entry(roster_file, host):
+    """
+    Writes a salt master entry to the specified roster file.
 
-# create dinamic roster
-with open(roster_file, 'a') as roster:
-    # take first as master
-    writeSaltMasterEntry(roster, ips.pop())
-    minionNumber = 1
-    for ip in ips:
-        writeSaltMinionEntry(roster, ip, minionNumber)
-        minionNumber += 1
+    :param roster_file: a file object to add the entry to
+    :param host: the ip address or hostname of the salt master host
+    """
+    roster_file.write(" salt-master:\n")
+    roster_file.write("   user: root\n")
+    roster_file.write("   host: {}\n".format(host))
 
-# remove host file (don't needed anymore)
-if os.path.exists(terraformHostsFile):
-    os.remove(terraformHostsFile)
+
+def write_salt_minion_entry(roster_file, host, minion_num):
+    """
+    Writes a salt minion entry to the specified roster file.
+
+    :param roster_file: a file object to add the entry to
+    :param host: the ip address or hostname of the salt minion
+    :param minion_num: the minion number to add
+    """
+    roster_file.write(" salt-minion{}:\n".format(minion_num))
+    roster_file.write("   user: root\n")
+    roster_file.write("   host: {}\n".format(host))
+
+
+def main():
+    """
+    Attempts to transcribe the contents of a host.txt file to a
+    roster file. Once the host file contents have been transcribed,
+    the old host file will be removed.
+
+    :return: 1 if the file does not exist or is empty, 0 otherwise
+    """
+    # host.txt was deleted just exit
+    if not os.path.exists(TERRAFORM_HOSTS_FILE):
+        print "hosts.txt doesn't exist anymore."
+        sys.exit(1)
+
+    # read terraform ips
+    if os.path.exists(DEFAULT_ROSTER_FILE):
+        os.remove(DEFAULT_ROSTER_FILE)
+
+    ips = read_ip_from_terraform(TERRAFORM_HOSTS_FILE)
+    if not ips:
+        print "hosts.txt empty"
+        sys.exit(1)
+
+    # create dynamic roster
+    with open(DEFAULT_ROSTER_FILE, "a") as roster:
+        # take first as master
+        write_salt_master_entry(roster, ips.pop())
+        for minion_number, host in enumerate(ips):
+            write_salt_minion_entry(roster, host, minion_number + 1)
+
+    # remove host file (don't needed anymore)
+    if os.path.exists(TERRAFORM_HOSTS_FILE):
+        os.remove(TERRAFORM_HOSTS_FILE)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR fixes the pylint warnings contained within the `create_roster.py` file. Summary of changes:

* `print` statements were assumed to be Python 2 compliant - braces removed from surrounding statements.
* All functions were given docstrings, including descriptions for input and output parameters.
* Two space indentations were fixed - moved to four spaces.
* Imports for `sys` and `os` moved into separate lines.
* Constants changed to uppercase snake_case convention.
* Function names changed to snake_case convention.
* Variable names changed to snake_case convention, and lengthened to be > 3 characters.
* Comments at top of file transformed into docstring.
* String concatenation removed in favour of `format` style variable insertion.
* Move main body of code into `main` function, to be called if the namespace is `__main__`.

Old pylint score = 2.19/10
New pylint score = 10/10

Tested manually on localhost using Python 2.7.15rc1 with pylint 1.8.3.