### PR TITLE
Add markdown table for supported operating systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,23 @@ WIP
 
 Have a look on the roadmap board under github Projects.
 
+# Supported Operating Systems
+
+| Operating System             | Version    | Supported          | Not Supported Yet |
+| ---------------------------- | :--------: | :----------------: | :---------------: |
+| Arch                         | 2018.10.01 |                    | :no_entry:        |
+| CentOS                       | 7.1        | :heavy_check_mark: |                   |
+| Debian                       |            |                    | :no_entry:        |
+| Fedora                       |            |                    | :no_entry:        |
+| Gentoo                       |            |                    | :no_entry:        |
+| Linux Mint                   |            |                    | :no_entry:        |
+| openSUSE                     | Leap 42.3  | :heavy_check_mark: |                   |
+| Oracle Linux                 |            |                    | :no_entry:        |
+| Red Hat Enterprise Linux     |            |                    | :no_entry:        |
+| Slackware                    |            |                    | :no_entry:        |
+| SUSE Linux Enterprise Server | 12 SP3     | :heavy_check_mark: |                   |
+| Ubuntu                       | 18.04      | :heavy_check_mark: |                   |
+
 # Contributing:
 
 Take a look on [contributing](CONTRIBUTING.md)


### PR DESCRIPTION
This PR adds a markdown table for supported operating systems. It contains four columns:

* Operating system name
* Version
* Supported
* Not supported yet

Github emojis are used to create colourful visual cues as to whether or not an operating system version is supported or not. See attached image below for example. This PR closes issue #22 

![markdown_table_example](https://user-images.githubusercontent.com/3108461/46851634-1f785a80-cdc6-11e8-8a0e-4d5638cf2026.png)